### PR TITLE
use string.format instead of % string formatting

### DIFF
--- a/navigation-history.py
+++ b/navigation-history.py
@@ -162,7 +162,7 @@ class NavigationHistoryBack(sublime_plugin.TextCommand):
         location = history.back()
         if location:
             window = sublime.active_window()
-            window.open_file("%s:%d:%d" % (location.path, location.line, location.col), sublime.ENCODED_POSITION)
+            window.open_file("{0}:{1}:{2}".format(location.path, location.line, location.col), sublime.ENCODED_POSITION)
 
 class NavigationHistoryForward(sublime_plugin.TextCommand):
     """Go forward in history
@@ -176,4 +176,4 @@ class NavigationHistoryForward(sublime_plugin.TextCommand):
         location = history.forward()
         if location:
             window = sublime.active_window()
-            window.open_file("%s:%d:%d" % (location.path, location.line, location.col), sublime.ENCODED_POSITION)
+            window.open_file("{0}:{1}:{2}".format(location.path, location.line, location.col), sublime.ENCODED_POSITION)


### PR DESCRIPTION
To support sublime 2 and 3 you will have to use the string.format method which is
compatable with both python 2.6 (st2) and python 3.3 (st3).  I have only tested this
with sublime text 2.
